### PR TITLE
Chore build refactor

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,0 @@
-FROM node:9.5.0
-
-COPY . /usr/src/
-WORKDIR /usr/src/
-RUN yarn install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ def version          = "0.0.${env.BUILD_NUMBER}"
 def repo             = "ifishgroup/pqvp-kmt"
 def nodeVersion      = '9.5.0'
 
-TERRAFORM_DIR     = 'deploy/docker-swarm/terraform/aws'
+TERRAFORM_DIR        = 'deploy/docker-swarm/terraform/aws'
+NOTIFICATIONS        = true
 
 node('docker') {
     stage('checkout') {
@@ -24,7 +25,6 @@ node('docker') {
         ]) {
             stage('e2e tests') {
                 try {
-                    sh "docker-compose build e2e"
                     sh "docker-compose run --rm e2e"
                 } catch(e) {
                     error "Failed: ${e}"
@@ -71,7 +71,7 @@ node('docker') {
                     stage('deploy staging') {
                         sh "${terraform()} apply $tfplan"
                         masterAddress = getMasterAddress()
-                        publishStagedInfo(masterAddress)
+                        publishStagedInfo(masterAddress) 
                     }
 
                     stage('UAT') {
@@ -106,27 +106,32 @@ node('docker') {
             } else {
                 def tfplan = "prod-${version}.tfplan"
 
-                stage('plan') {
-                    sh "cat $PQVP_KMT_PEM > $TERRAFORM_DIR/pem.txt"
-                    sh "cp docker-compose.yml $TERRAFORM_DIR"
-                    sh "${terraform()} init -backend-config=config/prod-state-store.tfvars -force-copy ."
-                    sh "${terraform()} taint null_resource.deploy_docker_stack"
-                    sh """${terraform()} plan \
-                        -var-file=config/prod.tfvars \
-                        -var tag=latest \
-                        -var private_key_path=pem.txt \
-                        -var git_commit=${gitCommit()} \
-                        -var git_branch=${env.BRANCH_NAME} \
-                        -var version=${version} \
-                        -out $tfplan \
-                        .
-                    """
-                }
+                try {
+                    stage('plan') {
+                        sh "cat $PQVP_KMT_PEM > $TERRAFORM_DIR/pem.txt"
+                        sh "cp docker-compose.yml $TERRAFORM_DIR"
+                        sh "${terraform()} init -backend-config=config/prod-state-store.tfvars -force-copy ."
+                        sh "${terraform()} taint null_resource.deploy_docker_stack"
+                        sh """${terraform()} plan \
+                            -var-file=config/prod.tfvars \
+                            -var tag=latest \
+                            -var private_key_path=pem.txt \
+                            -var git_commit=${gitCommit()} \
+                            -var git_branch=${env.BRANCH_NAME} \
+                            -var version=${version} \
+                            -out $tfplan \
+                            .
+                        """
+                    }
 
-                stage('deploy to prod') {
-                    sh "${terraform()} apply $tfplan"
-                    publishProdInfo(getMasterAddress())
-                }
+                    stage('deploy to prod') {
+                        sh "${terraform()} apply $tfplan"
+                        publishProdInfo(getMasterAddress())
+                    }
+                } catch(e) {
+                    error "Failed: ${e}"
+                    notifySlack("FAILED")
+                } 
             }
         }
     }
@@ -151,17 +156,19 @@ def publishProdInfo(String ip) {
 }
 
 def notifyGithub(String comment) {
-    withCredentials([
-        string(credentialsId: '96df6ea0-11f0-4868-a203-7dbfac9bef3d', variable: 'TOKEN')
-    ]) {
-        def pr  = env.BRANCH_NAME.split("-")[1].trim()
-        sh "curl -H \"Content-Type: application/json\" -u ifg-bot:$TOKEN -X POST -d '{\"body\": \"$comment\"}' https://api.github.com/repos/ifishgroup/pqvp-kmt/issues/$pr/comments"
+    if (NOTIFICATIONS) {
+        withCredentials([
+            string(credentialsId: '96df6ea0-11f0-4868-a203-7dbfac9bef3d', variable: 'TOKEN')
+        ]) {
+            def pr  = env.BRANCH_NAME.split("-")[1].trim()
+            sh "curl -H \"Content-Type: application/json\" -u ifg-bot:$TOKEN -X POST -d '{\"body\": \"$comment\"}' https://api.github.com/repos/ifishgroup/pqvp-kmt/issues/$pr/comments"
+        }
     }
 }
 
 def notifySlack(String buildStatus) {
-    if (env.BRANCH_NAME =~ /(?i)^pr-/ || env.BRANCH_NAME == "master") {
-         echo "currentBuild.result=$buildStatus"
+    if (NOTIFICATIONS) {
+        echo "currentBuild.result=$buildStatus"
 
         if (buildStatus != 'SUCCESS' && buildStatus != 'STARTED') {
             buildStatus = 'FAILED'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,21 +138,26 @@ node('docker') {
 }
 
 def publishStagedInfo(String ip) {
-    notifyGithub("${env.JOB_NAME}, build [#${env.BUILD_NUMBER}](${env.BUILD_URL}) - Staged deployment can be viewed at: [http://$ip](http://$ip). Staged builds require UAT, click on Jenkins link when finished with UAT to mark the build as 'pass' or 'failed'")
-    slackSend(color: 'good',
-        message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Staged deployment can be viewed at: http://$ip. Staged builds require UAT, click on Jenkins link when finished with testing to mark the build as 'pass' or 'failed'")
+    if (NOTIFICATIONS) {
+        notifyGithub("${env.JOB_NAME}, build [#${env.BUILD_NUMBER}](${env.BUILD_URL}) - Staged deployment can be viewed at: [http://$ip](http://$ip). Staged builds require UAT, click on Jenkins link when finished with UAT to mark the build as 'pass' or 'failed'")
+        slackSend(color: 'good',
+            message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Staged deployment can be viewed at: http://$ip. Staged builds require UAT, click on Jenkins link when finished with testing to mark the build as 'pass' or 'failed'")
+    }
 }
 
 def notifyTeardownEvent(String ip) {
-    notifyGithub("${env.JOB_NAME}, build [#${env.BUILD_NUMBER}](${env.BUILD_URL}) - Staged build @ $ip was removed")
-    slackSend(color: 'good',
-        message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Staged build @ $ip was removed")
+    if (NOTIFICATIONS) {
+        notifyGithub("${env.JOB_NAME}, build [#${env.BUILD_NUMBER}](${env.BUILD_URL}) - Staged build @ $ip was removed")
+        slackSend(color: 'good',
+            message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Staged build @ $ip was removed")
+    }
 }
 
 def publishProdInfo(String ip) {
-    notifyGithub("${env.JOB_NAME}, build [#${env.BUILD_NUMBER}](${env.BUILD_URL}) - Deployed to production, can be viewed at: [http://$ip](http://$ip).")
-    slackSend(color: 'good',
-        message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Deployed to production, can be viewed at: http://$ip.")
+    if (NOTIFICATIONS) {
+        slackSend(color: 'good',
+            message: "${env.JOB_NAME}, build #${env.BUILD_NUMBER} ${env.BUILD_URL} - Deployed to production, can be viewed at: http://$ip.")
+    }
 }
 
 def notifyGithub(String comment) {

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -2,14 +2,16 @@ version: '3'
 
 services:
   e2e:
-    build:
-      context: .
-      dockerfile: Dockerfile.e2e
+    image: node:9.5.0
+    user: 'node'
+    working_dir: '/usr/src/'
     depends_on:
       - "pqvp-kmt"
       - "chrome"
       - "hub"
-    command: ["./wait-for-it.sh", "hub:4444", "--", "yarn", "e2e-docker"]
+    volumes:
+      - ./:/usr/src/
+    command: ["./wait-for-it.sh", "hub:4444", "--", "bash", "-c", "yarn install && yarn e2e-docker"]
 
   pqvp-kmt:
     image: "ifishgroup/pqvp-kmt:${TAG}"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "e2e-docker": "node test/e2e/runner.js --config test/e2e/docker.nightwatch.conf.js",
     "test": "npm run unit && npm run e2e",
     "lint": "eslint --ext .js,.vue src test/unit test/e2e/specs",
-    "build": "node build/build.js"
+    "build": "node build/build.js",
+    "docker-build": "docker build -t ifishgroup/pqvp-kmt .",
+    "docker-e2e": "docker-compose -f docker-compose-e2e.yml run --rm e2e"
   },
   "dependencies": {
     "vue": "^2.5.2",


### PR DESCRIPTION
- Add flag to toggle notifications
- Add helper commands for building docker with yarn
- Remove Docker.e2e image, do work via compose
- Notify slack when master build fails to deploy to prod
- Fix issue causing master build to fail. It was attempting to notify github on deployment to production but the pr number didn't exist, will only notify slack when builds deploy to production.